### PR TITLE
Change unique constraint for Resources to Only be Unique within user

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -14,9 +14,9 @@
 #
 # Indexes
 #
-#  index_ingredients_on_name     (name) UNIQUE
-#  index_ingredients_on_slug     (slug) UNIQUE
-#  index_ingredients_on_user_id  (user_id)
+#  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_ingredients_on_slug              (slug) UNIQUE
+#  index_ingredients_on_user_id           (user_id)
 #
 # Foreign Keys
 #
@@ -28,17 +28,29 @@
 class Ingredient < ApplicationRecord
   extend FriendlyId
 
-  belongs_to :user # , optional: true
+  belongs_to :user
   has_many :step_ingredients, dependent: :destroy
   has_many :steps, through: :step_ingredients
   has_many :recipes, through: :steps
 
+
   validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: {
+    scope: [:user_id]
+  }
 
   accepts_nested_attributes_for :step_ingredients
 
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :scoped, :history], scope: [:user]
 
   scope :managed, -> { includes(:user) }
+
+  # Determines if a new slug should be generated. Currently this happens when the model is first created,
+  # and when the name is updated
+  #
+  # @return [Boolean]
+  #noinspection RubyInstanceMethodNamingConvention
+  def should_generate_new_friendly_id?
+    new_record? || name_changed?
+  end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -33,7 +33,6 @@ class Ingredient < ApplicationRecord
   has_many :steps, through: :step_ingredients
   has_many :recipes, through: :steps
 
-
   validates :name, presence: true
   validates :name, uniqueness: {
     scope: [:user_id]
@@ -41,7 +40,7 @@ class Ingredient < ApplicationRecord
 
   accepts_nested_attributes_for :step_ingredients
 
-  friendly_id :name, use: [:slugged, :scoped, :history], scope: [:user]
+  friendly_id :name, use: %i[slugged scoped history], scope: [:user]
 
   scope :managed, -> { includes(:user) }
 
@@ -49,7 +48,7 @@ class Ingredient < ApplicationRecord
   # and when the name is updated
   #
   # @return [Boolean]
-  #noinspection RubyInstanceMethodNamingConvention
+  # noinspection RubyInstanceMethodNamingConvention
   def should_generate_new_friendly_id?
     new_record? || name_changed?
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -16,9 +16,9 @@
 #
 # Indexes
 #
-#  index_recipes_on_name     (name) UNIQUE
-#  index_recipes_on_slug     (slug) UNIQUE
-#  index_recipes_on_user_id  (user_id)
+#  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_recipes_on_slug              (slug) UNIQUE
+#  index_recipes_on_user_id           (user_id)
 #
 # Foreign Keys
 #
@@ -35,14 +35,17 @@ class Recipe < ApplicationRecord
   }, dependent: :destroy
   has_many :ingredients, through: :steps
   has_many :citations
-  belongs_to :user # , optional: true
+  belongs_to :user
+
 
   validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: {
+    scope: [:user_id]
+  }
 
   accepts_nested_attributes_for(:steps, :citations)
 
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: [:slugged, :scoped, :history], scope: [:user]
 
   scope :managed, -> { includes(:user) }
   scope :publicly_accessible, -> { where(publicly_accessible: true) }
@@ -62,5 +65,14 @@ class Recipe < ApplicationRecord
   # @return [Recipe::ActiveRecord_Relation]
   def self.directory_recipes(page)
     order(:name).page(page)
+  end
+
+  # Determines if a new slug should be generated. Currently this happens when the model is first created,
+  # and when the name is updated
+  #
+  # @return [Boolean]
+  #noinspection RubyInstanceMethodNamingConvention
+  def should_generate_new_friendly_id?
+    new_record? || name_changed?
   end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -37,7 +37,6 @@ class Recipe < ApplicationRecord
   has_many :citations
   belongs_to :user
 
-
   validates :name, presence: true
   validates :name, uniqueness: {
     scope: [:user_id]
@@ -45,7 +44,7 @@ class Recipe < ApplicationRecord
 
   accepts_nested_attributes_for(:steps, :citations)
 
-  friendly_id :name, use: [:slugged, :scoped, :history], scope: [:user]
+  friendly_id :name, use: %i[slugged scoped history], scope: [:user]
 
   scope :managed, -> { includes(:user) }
   scope :publicly_accessible, -> { where(publicly_accessible: true) }
@@ -71,7 +70,7 @@ class Recipe < ApplicationRecord
   # and when the name is updated
   #
   # @return [Boolean]
-  #noinspection RubyInstanceMethodNamingConvention
+  # noinspection RubyInstanceMethodNamingConvention
   def should_generate_new_friendly_id?
     new_record? || name_changed?
   end

--- a/app/views/manage/legacy/authors/show.html.erb
+++ b/app/views/manage/legacy/authors/show.html.erb
@@ -14,7 +14,7 @@
 <nav class="action-links-navbar">
   <ul class="action-links">
     <li class="action-link"><span><%= link_to "Edit", edit_manage_legacy_recipe_citation_author_path(@author.citation.recipe, @author.citation, @author) %></span></li>
-    <li class="action-link"><span><%= link_to "Delete", {action: :destroy, method: :delete, recipe_id: @author.citation.recipe.id, citation_id: @author.citation.id, id: @author.id, data: {confirm: "Are you sure?"}} %></span></li>
+    <li class="action-link"><span><%= link_to "Delete", manage_legacy_recipe_citation_path(@author.citation.recipe, @author.citation, @author), {action: :destroy, method: :delete, recipe_id: @author.citation.recipe.id, citation_id: @author.citation.id, id: @author.id, data: {confirm: "Are you sure?"}} %></span></li>
     <li class="action-link"><span><%= link_to "Back", manage_legacy_recipe_citation_path(@author.citation.recipe, @author.citation) %></span></li>
   </ul>
 </nav>

--- a/app/views/manage/legacy/citations/show.html.erb
+++ b/app/views/manage/legacy/citations/show.html.erb
@@ -18,7 +18,7 @@
             <div class="citation-author-links manage-resource-links">
               <span><%= link_to "Show", manage_legacy_recipe_citation_authors_path(author.citation.recipe, author.citation, author) %></span>
               <span><%= link_to "Edit", edit_manage_legacy_recipe_citation_author_path(author.citation.recipe, author.citation, author) %></span>
-              <span><%= link_to "Delete", {action: :destroy, method: :delete, recipe_id: author.citation.recipe, citation_id: author.citation.id, id: author.id, data: {confirm: "Are you sure?"}} %></span>
+              <span><%= link_to "Delete", manage_legacy_recipe_citation_author_path(author.citation.recipe, author.citation, author), {action: :destroy, method: :delete, recipe_id: author.citation.recipe, citation_id: author.citation.id, id: author.id, data: {confirm: "Are you sure?"}} %></span>
             </div>
           </li>
         <% end %>
@@ -30,7 +30,7 @@
 <nav class="action-links-navbar">
   <ul class="action-links">
     <li class="action-link"><span><%= link_to "Edit", edit_manage_legacy_recipe_citation_path(@citation.recipe, @citation) %></span></li>
-    <li class="action-link"><span><%= link_to "Delete", {action: :destroy, method: :delete, recipe_id: @citation.recipe.id, id: @citation.id, data: [confirm: "Are you sure?"]} %></span></li>
+    <li class="action-link"><span><%= link_to "Delete", manage_legacy_recipe_citation_path(@citation.recipe, @citation), {action: :destroy, method: :delete, recipe_id: @citation.recipe.id, id: @citation.id, data: [confirm: "Are you sure?"]} %></span></li>
     <li class="action-link"><span><%= link_to "Back", manage_legacy_recipe_path(@citation.recipe) %></span></li>
   </ul>
 </nav>

--- a/app/views/manage/legacy/recipes/index.html.erb
+++ b/app/views/manage/legacy/recipes/index.html.erb
@@ -11,7 +11,7 @@
         <span><%= link_to recipe.name, manage_legacy_recipe_path(recipe) %></span>
         <div class="recipe-links">
           <span><%= link_to "Edit", edit_manage_legacy_recipe_path(recipe) %></span>
-          <span><%= link_to "Delete", {action: :destroy, method: :delete, id: recipe.id, data: {confirm: "Are you sure?"}} %></span>
+          <span><%= link_to "Delete", manage_legacy_recipe_path(recipe), {action: :destroy, method: :delete, id: recipe.id, data: {confirm: "Are you sure?"}} %></span>
         </div>
       </li>
     <% end %>

--- a/app/views/manage/legacy/recipes/show.html.erb
+++ b/app/views/manage/legacy/recipes/show.html.erb
@@ -44,7 +44,7 @@
 <nav class="action-links-navbar">
   <ul class="action-links">
     <li class="action-link"><%= link_to "Edit", edit_manage_legacy_recipe_path(@recipe) %></li>
-    <li class="action-link"><%= link_to "Delete", {action: :destroy, method: :delete, id: @recipe.id, data: {confirm: "Are you sure?"}} %></li>
+    <li class="action-link"><%= link_to "Delete", manage_legacy_recipe_path(@recipe), {action: :destroy, method: :delete, id: @recipe.id, data: {confirm: "Are you sure?"}} %></li>
     <li class="action-link"><%= link_to "Back", manage_legacy_recipes_path %></li>
   </ul>
 </nav>

--- a/app/views/manage/legacy/steps/show.html.erb
+++ b/app/views/manage/legacy/steps/show.html.erb
@@ -16,7 +16,7 @@
             <div class="step-ingredient-links manage-resource-links">
               <span><%= link_to "Show", manage_legacy_recipe_step_step_ingredient_path(step_ingredient.step.recipe.id, step_ingredient.step.id, step_ingredient) %></span>
               <span><%= link_to "Edit", edit_manage_legacy_recipe_step_step_ingredient_path(step_ingredient.step.recipe.id, step_ingredient.step.id, step_ingredient) %></span>
-              <span><%= link_to "Delete", {action: :destroy, method: :delete, recipe_id: step_ingredient.step.recipe.id, step_id: step_ingredient.id, id: step_ingredient.id, data: {confirm: "Are you sure?"}} %></span>
+              <span><%= link_to "Delete", manage_legacy_recipe_step_step_ingredient_path(step_ingredient.step.recipe.id, step_ingredient.step.id, step_ingredient), {action: :destroy, method: :delete, recipe_id: step_ingredient.step.recipe.id, step_id: step_ingredient.id, id: step_ingredient.id, data: {confirm: "Are you sure?"}} %></span>
             </div>
           </li>
         <% end %>
@@ -28,7 +28,7 @@
 <nav class="action-links-navbar">
   <ul class="action-links">
     <li class="action-link"><span><%= link_to "Edit", edit_manage_legacy_recipe_step_path(@step.recipe_id, @step) %></span></li>
-    <li class="action-link"><span><%= link_to "Delete", {action: :destroy, method: :delete, recipe_id: @step.recipe.id, id: @step.id, data: {confirm: "Are you sure?"}} %></span></li>
+    <li class="action-link"><span><%= link_to "Delete", manage_legacy_recipe_step_path(@step.recipe_id, @step), {action: :destroy, method: :delete, recipe_id: @step.recipe.id, id: @step.id, data: {confirm: "Are you sure?"}} %></span></li>
     <li class="action-link"><span><%= link_to "Back", manage_legacy_recipe_path(@step.recipe_id) %></span></li>
   </ul>
 </nav>

--- a/db/migrate/20211117044827_change_resources_unique_to_users.rb
+++ b/db/migrate/20211117044827_change_resources_unique_to_users.rb
@@ -1,0 +1,11 @@
+class ChangeResourcesUniqueToUsers < ActiveRecord::Migration[6.1]
+  def change
+    # Constrain Ingredients to Users
+    remove_index :ingredients, :name
+    add_index :ingredients, [:name, :user_id], unique: true
+
+    # Constraint Recipes to Users
+    remove_index :recipes, :name
+    add_index :recipes, [:name, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_08_054815) do
+ActiveRecord::Schema.define(version: 2021_11_17_044827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2021_11_08_054815) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.string "slug"
-    t.index ["name"], name: "index_ingredients_on_name", unique: true
+    t.index ["name", "user_id"], name: "index_ingredients_on_name_and_user_id", unique: true
     t.index ["slug"], name: "index_ingredients_on_slug", unique: true
     t.index ["user_id"], name: "index_ingredients_on_user_id"
   end
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2021_11_08_054815) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.string "slug"
-    t.index ["name"], name: "index_recipes_on_name", unique: true
+    t.index ["name", "user_id"], name: "index_recipes_on_name_and_user_id", unique: true
     t.index ["slug"], name: "index_recipes_on_slug", unique: true
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end

--- a/notes/ROADMAP.md
+++ b/notes/ROADMAP.md
@@ -1,7 +1,6 @@
 # Roadmap
 
-- Pagination and Query Limiting
-- Active Storage Integration
+- Image Management Integration
 - Better Resource Management
 - GitHub Actions Workflows
 - Maintenance Mode for Recipes Currently Undergoing Heavy Changes

--- a/test/factories/ingredients.rb
+++ b/test/factories/ingredients.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: ingredients
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_ingredients_on_slug              (slug) UNIQUE
+#  index_ingredients_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :ingredient do
     name { Faker::Food.unique.ingredient }

--- a/test/factories/recipes.rb
+++ b/test/factories/recipes.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id                  :bigint           not null, primary key
+#  description         :text
+#  image_url           :string
+#  name                :string           not null
+#  publicly_accessible :boolean          default(FALSE), not null
+#  slug                :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint
+#
+# Indexes
+#
+#  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_recipes_on_slug              (slug) UNIQUE
+#  index_recipes_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :recipe do
     name { Faker::Food.dish + SecureRandom.uuid }

--- a/test/factories/step_ingredients.rb
+++ b/test/factories/step_ingredients.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: step_ingredients
+#
+#  id            :bigint           not null, primary key
+#  amount        :decimal(, )      not null
+#  condition     :string
+#  unit          :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  ingredient_id :bigint           not null
+#  step_id       :bigint           not null
+#
+# Indexes
+#
+#  index_step_ingredients_on_ingredient_id  (ingredient_id)
+#  index_step_ingredients_on_step_id        (step_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (ingredient_id => ingredients.id)
+#  fk_rails_...  (step_id => steps.id)
+#
 FactoryBot.define do
   factory :step_ingredient do
     amount { Faker::Number.between(from: 1, to: 10) }

--- a/test/factories/steps.rb
+++ b/test/factories/steps.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: steps
+#
+#  id          :bigint           not null, primary key
+#  instruction :text             not null
+#  order       :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  recipe_id   :bigint           not null
+#
+# Indexes
+#
+#  index_steps_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
+#
 FactoryBot.define do
   factory :step do
     order { Faker::Number.between(from: 1, to: 100) }

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -38,6 +38,6 @@ class IngredientTest < ActiveSupport::TestCase
 
   context 'validations' do
     should validate_presence_of(:name)
-    should validate_uniqueness_of(:name)
+    should validate_uniqueness_of(:name).scoped_to(:user_id)
   end
 end

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -12,9 +12,9 @@
 #
 # Indexes
 #
-#  index_ingredients_on_name     (name) UNIQUE
-#  index_ingredients_on_slug     (slug) UNIQUE
-#  index_ingredients_on_user_id  (user_id)
+#  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_ingredients_on_slug              (slug) UNIQUE
+#  index_ingredients_on_user_id           (user_id)
 #
 # Foreign Keys
 #

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -14,9 +14,9 @@
 #
 # Indexes
 #
-#  index_recipes_on_name     (name) UNIQUE
-#  index_recipes_on_slug     (slug) UNIQUE
-#  index_recipes_on_user_id  (user_id)
+#  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
+#  index_recipes_on_slug              (slug) UNIQUE
+#  index_recipes_on_user_id           (user_id)
 #
 # Foreign Keys
 #

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -41,7 +41,7 @@ class RecipeTest < ActiveSupport::TestCase
 
   context 'validations' do
     should validate_presence_of(:name)
-    should validate_uniqueness_of(:name)
+    should validate_uniqueness_of(:name).scoped_to(:user_id)
   end
 
   context 'queries' do


### PR DESCRIPTION
Each user might have their own version of a Recipe, and so they shouldn't be constrained globally by recipe name.

Similarly, each user might have their own ingredients/information they want about their ingredients, and so that should not be constrained either.

This changes the index to only require it to be unique within a particular user.


Additionally, some broken links were fixed, and the slug logic was fixed to update slugs when the resources updated.