### PR TITLE
Setup Top-Level Resource Notes

### DIFF
--- a/app/assets/stylesheets/manage/_form.scss
+++ b/app/assets/stylesheets/manage/_form.scss
@@ -168,3 +168,20 @@ New Recipe
 .new-resource-note {
   text-align: center;
 }
+
+.notes-container {
+  height: 50vh;
+  border: 1px solid black;
+  border-radius: 10px;
+  padding: 1%;
+  margin: 1% auto;
+
+  #resource_notes {
+    border: 1px solid black;
+    height: 60%;
+    margin: 1% auto;
+    padding: 1%;
+    border-radius: 10px;
+    overflow-y: scroll;
+  }
+}

--- a/app/controllers/manage/ingredients_controller.rb
+++ b/app/controllers/manage/ingredients_controller.rb
@@ -52,7 +52,12 @@ class Manage::IngredientsController < Manage::ApplicationController
       :id,
       :name,
       :description,
-      gallery_pictures: []
+      gallery_pictures: [],
+      notes_attributes: %i[
+        id
+        content
+        _destroy
+      ]
     )
   end
 end

--- a/app/controllers/manage/recipes_controller.rb
+++ b/app/controllers/manage/recipes_controller.rb
@@ -99,6 +99,11 @@ class Manage::RecipesController < Manage::ApplicationController
         order
         instruction
         _destroy
+      ],
+      notes_attributes: %i[
+        id
+        content
+        _destroy
       ]
     )
   end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -30,7 +30,7 @@ class Ingredient < ApplicationRecord
   has_many :step_ingredients, dependent: :destroy
   has_many :steps, through: :step_ingredients
   has_many :recipes, through: :steps
-
+  has_many :notes, as: :notable, class_name: 'Note'
   has_many_attached_with :gallery_pictures, path: -> { "#{Rails.application.config.x.resource_prefix}/ingredients" }
 
   validates :name, presence: true
@@ -41,6 +41,8 @@ class Ingredient < ApplicationRecord
   friendly_id :name, use: %i[slugged scoped history], scope: [:user]
 
   scope :managed, -> { includes(:user) }
+
+  accepts_nested_attributes_for :notes, reject_if: :all_blank, allow_destroy: true
 
   # Determines if a new slug should be generated. Currently this happens when the model is first created,
   # and when the name is updated

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id           :integer          not null, primary key
+#  content      :text             not null
+#  notable_type :string           not null
+#  notable_id   :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_notes_on_notable  (notable_type,notable_id)
+#
+
+# Represents a simple extra note on a top-level resource (i.e. Recipe, Ingredient, etc.)
+class Note < ApplicationRecord
+  belongs_to :notable, polymorphic: true
+
+  validates :content, :notable, presence: true
+
+  def recipe
+    Recipe.joins('JOIN notes ON recipes.id = notes.notable_id').where(recipes: { id: notable_id })
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -32,6 +32,7 @@ class Recipe < ApplicationRecord
   has_many :ingredients, through: :steps
   has_many :citations
   belongs_to :user
+  has_many :notes, as: :notable, class_name: 'Note'
   has_one_attached_with :primary_picture, path: -> { "#{Rails.application.config.x.resource_prefix}/recipes" }
   has_many_attached_with :gallery_pictures, path: -> { "#{Rails.application.config.x.resource_prefix}/recipes" }
 
@@ -39,12 +40,13 @@ class Recipe < ApplicationRecord
   validates :name, uniqueness: {
     scope: [:user_id]
   }
-  validates_associated :steps
+  validates_associated :steps, :notes
 
   before_save :consolidate_step_order
 
   accepts_nested_attributes_for :steps, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :citations, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :notes, reject_if: :all_blank, allow_destroy: true
 
   friendly_id :name, use: %i[slugged scoped history], scope: [:user]
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -23,6 +23,7 @@ class Step < ApplicationRecord
   belongs_to :recipe
   has_many :step_ingredients, dependent: :destroy
   has_many :ingredients, through: :step_ingredients
+  # has_many :notes, as: :notable
   has_many_attached_with :gallery_pictures, path: -> { "#{Rails.application.config.x.resource_prefix}/steps" }
 
   validates :order, :instruction, :recipe, presence: true

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class NotePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def new?
+    true
+  end
+
+  def create?
+    allowed_to?(:create?, record.recipe)
+  end
+
+  def show?
+    allowed_to?(:show?, record.recipe)
+  end
+
+  def edit?
+    allowed_to?(:edit?, record.recipe)
+  end
+
+  def update?
+    allowed_to?(:update?, record.recipe)
+  end
+
+  def destroy?
+    allowed_to?(:destroy?, record.recipe)
+  end
+end

--- a/app/views/application/manage/notes/_note.html.erb
+++ b/app/views/application/manage/notes/_note.html.erb
@@ -1,0 +1,21 @@
+<li class="resource-item recipe-note nested-form-wrapper" data-new-record="<%= notes_form.object.new_record? %>">
+  <div class="form-ctrl-container">
+    <%= notes_form.text_area :content, class: "form-ctrl-text" %>
+  </div>
+
+  <div class="nested-form-actions">
+    <button type="button" class="cancel-btn" data-action="nested-form#remove">
+      Remove Note
+    </button>
+
+    <button type="button" class="undo-remove-btn hidden" data-action="nested-form#undoRemove">
+      Undo Remove
+    </button>
+
+    <% unless notes_form.object.new_record? %>
+      <%= link_to 'Edit', decorated_query_url_for(edit_manage_recipe_path(notes_form.object.recipe), {tab: 'information'}), data: {"turbo-frame": :"tab_content", turbo: false}, class: 'nested-form-nav-link' %>
+    <% end %>
+  </div>
+
+  <%= notes_form.hidden_field :_destroy %>
+</li>

--- a/app/views/application/manage/notes/_tab.html.erb
+++ b/app/views/application/manage/notes/_tab.html.erb
@@ -1,0 +1,19 @@
+<div class="notes-container">
+  <h3 class="tab-form-heading">Notes</h3>
+
+  <template data-nested-form-target="template">
+    <%= form.fields_for :notes, Note.new, child_index: 'NEW_RECORD' do |notes_form| %>
+      <%= render partial: 'application/manage/notes/note', locals: {notes_form: notes_form} %>
+    <% end %>
+  </template>
+
+  <ul id="resource_notes" class="resource-list" data-nested-form-target="target">
+    <% if form.object.notes.present? %>
+      <%= form.fields_for :notes do |notes_form| %>
+        <%= render partial: 'application/manage/notes/note', locals: {notes_form: notes_form} %>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <button type="button" class="button add-resource-btn" data-action="nested-form#add">Add Note</button>
+</div>

--- a/app/views/application/manage/recipes/_information.html.erb
+++ b/app/views/application/manage/recipes/_information.html.erb
@@ -1,9 +1,8 @@
 <%= turbo_frame_tag('tab_content') do %>
   <h3 class="tab-form-heading">Information</h3>
 
-  <%= form_with model: @recipe, class: 'resource-form', url: action, data: {turbo: false} do |recipe_form| %>
+  <%= form_with model: @recipe, class: 'resource-form', url: action, data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false } do |recipe_form| %>
     <section class="tab-form-section information">
-
       <div class="form-ctrl-container">
         <%= recipe_form.label :name, class: "form-ctrl-lbl" %>
         <%= recipe_form.text_field :name, class: "form-ctrl" %>
@@ -22,6 +21,10 @@
 
     <section class="tab-form-section images">
       <%= render partial: 'application/manage/recipes/images/tab', locals: {form: recipe_form} %>
+    </section>
+
+    <section class="tab-form-section notes">
+      <%= render partial: 'application/manage/notes/tab', locals: {form: recipe_form} %>
     </section>
 
     <%= recipe_form.submit %>

--- a/app/views/application/manage/recipes/steps/_full.html.erb
+++ b/app/views/application/manage/recipes/steps/_full.html.erb
@@ -2,7 +2,7 @@
   <h3 class="tab-form-heading">Step</h3>
 
   <%= form_with model: @step, class: 'resource-form', url: decorated_query_url_for(action, {tab: 'ingredients'}), data: {controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false} do |step_form| %>
-    <div class="tab-form-section step-ingredients">
+    <section class="tab-form-section step-ingredients">
       <template data-nested-form-target="template">
         <%= step_form.fields_for :step_ingredients, StepIngredient.new(ingredient: Ingredient.new), child_index: 'NEW_RECORD' do |step_ingredients_form| %>
           <%= render partial: 'application/manage/recipes/steps/ingredients/one', locals: {step_ingredients_form: step_ingredients_form} %>
@@ -23,11 +23,11 @@
       </ul>
 
       <button type="button" class="button add-resource-btn" data-action="nested-form#add">Add Ingredient</button>
-    </div>
+    </section>
 
-    <div class="tab-form-section images">
+    <section class="tab-form-section images">
       <%= render partial: 'application/manage/recipes/steps/images/tab', locals: {step_form: step_form} %>
-    </div>
+    </section>
 
     <%= step_form.submit %>
   <% end %>

--- a/app/views/application/manage/recipes/steps/ingredients/_full.html.erb
+++ b/app/views/application/manage/recipes/steps/ingredients/_full.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag('tab_content') do %>
   <h3 class="tab-form-heading">Ingredient</h3>
 
-  <%= form_with model: @ingredient, class: 'resource-form', url: decorated_query_url_for(action, {tab: 'ingredient'}), data: { turbo: false} do |ingredient_form| %>
-    <div class="tab-form-section ingredient">
+  <%= form_with model: @ingredient, class: 'resource-form', url: decorated_query_url_for(action, {tab: 'ingredient'}), data: { controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper', turbo: false} do |ingredient_form| %>
+    <section class="tab-form-section ingredient">
       <div class="form-ctrl-container">
         <%= ingredient_form.label :name, class: "form-ctrl-lbl" %>
         <%= ingredient_form.text_field :name, class: "form-ctrl" %>
@@ -12,11 +12,15 @@
         <%= ingredient_form.label :description, class: "form-ctrl-lbl" %>
         <%= ingredient_form.text_area :description, class: "form-ctrl" %>
       </div>
-    </div>
+    </section>
 
-    <div class="tab-form-section images">
+    <section class="tab-form-section images">
       <%= render partial: 'application/manage/recipes/steps/ingredients/images/tab', locals: {ingredient_form: ingredient_form} %>
-    </div>
+    </section>
+
+    <section class="tab-form-section notes">
+      <%= render partial: 'application/manage/notes/tab', locals: {form: ingredient_form} %>
+    </section>
 
     <%= ingredient_form.submit %>
   <% end %>

--- a/db/migrate/20220208042502_create_notes.rb
+++ b/db/migrate/20220208042502_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notes do |t|
+      t.text :content, null: false
+      t.references :notable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_22_072304) do
+ActiveRecord::Schema.define(version: 2022_02_08_042502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -94,6 +94,15 @@ ActiveRecord::Schema.define(version: 2021_11_22_072304) do
     t.index ["name", "user_id"], name: "index_ingredients_on_name_and_user_id", unique: true
     t.index ["slug"], name: "index_ingredients_on_slug", unique: true
     t.index ["user_id"], name: "index_ingredients_on_user_id"
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.text "content", null: false
+    t.string "notable_type", null: false
+    t.bigint "notable_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notable_type", "notable_id"], name: "index_notes_on_notable"
   end
 
   create_table "recipes", force: :cascade do |t|

--- a/notes/ROADMAP.md
+++ b/notes/ROADMAP.md
@@ -1,7 +1,6 @@
 # Roadmap
 
 ## Features
-- Recipe, Step, and Ingredient Notes
 - Recipe/User Ingredients vs. Canonical Ingredients
   - Migration Notes: When the time comes to implement this feature, all existing ingredients would become Recipe/User Ingredients that may be linked to canonical ingredients as needed
 - Article Content

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: notes
+#
+#  id           :integer          not null, primary key
+#  content      :text             not null
+#  notable_type :string           not null
+#  notable_id   :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_notes_on_notable  (notable_type,notable_id)
+#
+
+FactoryBot.define do
+  factory :note do
+    content { Faker::Movies::StarWars.quote }
+
+    transient do
+      notable { nil }
+    end
+
+    notable_id { notable.id }
+    notable_type { notable.class.name }
+  end
+end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: notes
+#
+#  id           :integer          not null, primary key
+#  content      :text             not null
+#  notable_type :string           not null
+#  notable_id   :integer          not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_notes_on_notable  (notable_type,notable_id)
+#
+
+require "test_helper"
+
+class NoteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/policies/note_policy_test.rb
+++ b/test/policies/note_policy_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+# See https://actionpolicy.evilmartians.io/#/testing?id=testing-policies
+class NotePolicyTest < ActiveSupport::TestCase
+  def test_index
+  end
+
+  def test_create
+  end
+
+  def test_manage
+  end
+end


### PR DESCRIPTION
This adds support for adding simple notes to Recipes and Ingredients.

The data model was added, and support for CRUD actions on notes were added under Recipe and Ingredient tabs in the resource management panes. At the moment, notes are not yet displayed in the public UI, just under the management UI