### PR TITLE
Add Canonical Ingredients Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem 'kaminari'
 # CORS
 gem 'rack-cors'
 
+# Efficient tree structure querying
+gem 'ancestry'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   # NOTE: There is a bug with running a Foreman configuration and this application's configuration that causes an error

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ancestry (4.1.0)
+      activerecord (>= 5.2.6)
     annotate (2.6.5)
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
@@ -357,6 +359,7 @@ PLATFORMS
 
 DEPENDENCIES
   action_policy
+  ancestry
   annotate
   argon2 (>= 2)
   aws-sdk-s3

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: ingredients
@@ -11,9 +10,11 @@
 #  updated_at  :datetime         not null
 #  user_id     :integer
 #  slug        :string
+#  ancestry    :string
 #
 # Indexes
 #
+#  index_ingredients_on_ancestry          (ancestry)
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)
@@ -33,6 +34,8 @@ class Ingredient < ApplicationRecord
   has_many :notes, as: :notable, class_name: 'Note'
   has_many_attached_with :gallery_pictures, path: -> { "#{Rails.application.config.x.resource_prefix}/ingredients" }
 
+  has_ancestry orphan_strategy: :rootify, touch: true
+
   validates :name, presence: true
   validates :name, uniqueness: {
     scope: [:user_id]
@@ -51,5 +54,9 @@ class Ingredient < ApplicationRecord
   # noinspection RubyInstanceMethodNamingConvention
   def should_generate_new_friendly_id?
     new_record? || name_changed?
+  end
+
+  def canonical?
+    is_root?
   end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: ingredients

--- a/db/migrate/20220210040240_add_ancestry_to_ingredients.rb
+++ b/db/migrate/20220210040240_add_ancestry_to_ingredients.rb
@@ -1,0 +1,6 @@
+class AddAncestryToIngredients < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ingredients, :ancestry, :string
+    add_index :ingredients, :ancestry, order: {slug: :text_pattern_ops}
+  end
+end

--- a/db/migrate/20220210040240_add_ancestry_to_ingredients.rb
+++ b/db/migrate/20220210040240_add_ancestry_to_ingredients.rb
@@ -1,6 +1,7 @@
 class AddAncestryToIngredients < ActiveRecord::Migration[7.0]
   def change
     add_column :ingredients, :ancestry, :string
-    add_index :ingredients, :ancestry, order: {slug: :text_pattern_ops}
+    # text_pattern_ops is a recommended optimization of the ancestry column index: https://github.com/stefankroes/ancestry
+    add_index :ingredients, :ancestry, order: {ancestry: :text_pattern_ops}
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_042502) do
+ActiveRecord::Schema.define(version: 2022_02_10_040240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -91,6 +91,8 @@ ActiveRecord::Schema.define(version: 2022_02_08_042502) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.string "slug"
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_ingredients_on_ancestry", opclass: :text_pattern_ops
     t.index ["name", "user_id"], name: "index_ingredients_on_name_and_user_id", unique: true
     t.index ["slug"], name: "index_ingredients_on_slug", unique: true
     t.index ["user_id"], name: "index_ingredients_on_user_id"

--- a/notes/ROADMAP.md
+++ b/notes/ROADMAP.md
@@ -1,13 +1,13 @@
 # Roadmap
 
 ## Features
-- Recipe/User Ingredients vs. Canonical Ingredients
-  - Migration Notes: When the time comes to implement this feature, all existing ingredients would become Recipe/User Ingredients that may be linked to canonical ingredients as needed
+- User types
 - Article Content
   - Tips
   - Tools
   - Possible Product Referral Links (avoid on main Recipe content)
   - Blog-version article of recipe
+- Resource Limits
 - Personal Recipe Downloads
 - Bulk Recipe Uploads
 - User Interaction Features

--- a/test/factories/ingredients.rb
+++ b/test/factories/ingredients.rb
@@ -9,9 +9,11 @@
 #  updated_at  :datetime         not null
 #  user_id     :integer
 #  slug        :string
+#  ancestry    :string
 #
 # Indexes
 #
+#  index_ingredients_on_ancestry          (ancestry)
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -9,9 +9,11 @@
 #  updated_at  :datetime         not null
 #  user_id     :integer
 #  slug        :string
+#  ancestry    :string
 #
 # Indexes
 #
+#  index_ingredients_on_ancestry          (ancestry)
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)


### PR DESCRIPTION
This adds support for a "canonical" (name maybe could use some work) ingredient concept. 

The idea here is to allow users to have their own "private" collection of ingredients, which they may then be able to link to to a "canonical" ingredient managed by an admin user.

The "canonical" ingredient is what may have more first-class support with future search and content related features, and will be held to a higher standard. Meanwhile, the "private" user ingredients are much more relaxed, allowing for variations in spelling, or just new ingredients/ingredient mixtures that an individual user may want to make use of, which we don't need to worry about compromising overall quality of public ingredients on the site.