### PR TITLE
Harden Registration Process Against Malicious Users

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Mailer for sending emails to admin users
+class AdminMailer < ApplicationMailer
+  # Sends email to all admin users indicating that a new user has registered and needs approval
+  #
+  # @param [String] email Email address of user that wants to register with site
+  def new_user_waiting_for_approval(email)
+    @email = email
+
+    admin_emails = User.with_role(:admin).pluck(:email)
+    if admin_emails.empty?
+      raise 'No admins currently available to approve user'
+    end
+
+    mail(to: admin_emails, subject: 'New user awaiting admin approval')
+  end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -9,9 +9,7 @@ class AdminMailer < ApplicationMailer
     @email = email
 
     admin_emails = User.with_role(:admin).pluck(:email)
-    if admin_emails.empty?
-      raise 'No admins currently available to approve user'
-    end
+    raise 'No admins currently available to approve user' if admin_emails.empty?
 
     mail(to: admin_emails, subject: 'New user awaiting admin approval')
   end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -4,18 +4,22 @@
 #
 # Table name: authors
 #
-#  id          :integer          not null, primary key
+#  id          :bigint           not null, primary key
 #  first_name  :string           not null
 #  last_name   :string
 #  middle_name :string
-#  citation_id :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  citation_id :bigint           not null
 #
 # Indexes
 #
 #  index_authors_on_citation_id               (citation_id)
 #  index_authors_on_last_name_and_first_name  (last_name,first_name)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (citation_id => citations.id)
 #
 
 # Represents Authors in the context of Recipe Citations

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -4,25 +4,29 @@
 #
 # Table name: citations
 #
-#  id                   :integer          not null, primary key
-#  origin               :string           not null
-#  content_type         :string           not null
-#  publication_title    :string
-#  publication_location :string
-#  publisher            :string
-#  published_at         :date
+#  id                   :bigint           not null, primary key
 #  content_location     :string
-#  version              :string
-#  site_title           :string
+#  content_type         :string           not null
 #  last_accessed_at     :date
+#  origin               :string           not null
+#  publication_location :string
+#  publication_title    :string
+#  published_at         :date
+#  publisher            :string
 #  site_link            :string
-#  recipe_id            :integer          not null
+#  site_title           :string
+#  version              :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  recipe_id            :bigint           not null
 #
 # Indexes
 #
 #  index_citations_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 # Handles data for any citations that need to be cited as having contributed in some way to the Recipe.

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,14 +4,14 @@
 #
 # Table name: ingredients
 #
-#  id          :integer          not null, primary key
-#  name        :string           not null
+#  id          :bigint           not null, primary key
+#  ancestry    :string
 #  description :text
+#  name        :string           not null
+#  slug        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  user_id     :integer
-#  slug        :string
-#  ancestry    :string
+#  user_id     :bigint
 #
 # Indexes
 #
@@ -19,6 +19,10 @@
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 # Holds all information relating to an overall ingredient itself, not related directly to a Recipe that

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,12 +4,12 @@
 #
 # Table name: notes
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  content      :text             not null
 #  notable_type :string           not null
-#  notable_id   :integer          not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  notable_id   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,20 +4,24 @@
 #
 # Table name: recipes
 #
-#  id                  :integer          not null, primary key
-#  name                :string           not null
+#  id                  :bigint           not null, primary key
 #  description         :text
-#  publicly_accessible :boolean          default("false"), not null
+#  name                :string           not null
+#  publicly_accessible :boolean          default(FALSE), not null
+#  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  user_id             :integer
-#  slug                :string
+#  user_id             :bigint
 #
 # Indexes
 #
 #  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_recipes_on_slug              (slug) UNIQUE
 #  index_recipes_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 # Holds all information relating to an overall recipe itself

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -4,12 +4,12 @@
 #
 # Table name: roles
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  resource_type :string
-#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  resource_id   :bigint
 #
 # Indexes
 #

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -4,16 +4,20 @@
 #
 # Table name: steps
 #
-#  id          :integer          not null, primary key
-#  order       :integer          not null
+#  id          :bigint           not null, primary key
 #  instruction :text             not null
-#  recipe_id   :integer          not null
+#  order       :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  recipe_id   :bigint           not null
 #
 # Indexes
 #
 #  index_steps_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 # Contains information for a specific recipe step

--- a/app/models/step_ingredient.rb
+++ b/app/models/step_ingredient.rb
@@ -4,19 +4,24 @@
 #
 # Table name: step_ingredients
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  amount        :decimal(, )      not null
-#  unit          :string
 #  condition     :string
-#  step_id       :integer          not null
-#  ingredient_id :integer          not null
+#  unit          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  ingredient_id :bigint           not null
+#  step_id       :bigint           not null
 #
 # Indexes
 #
 #  index_step_ingredients_on_ingredient_id  (ingredient_id)
 #  index_step_ingredients_on_step_id        (step_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (ingredient_id => ingredients.id)
+#  fk_rails_...  (step_id => steps.id)
 #
 
 # Links an ingredient to a specific recipe step. Contains step specific information about an ingredient, such

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,17 +4,18 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string           default(""), not null
-#  username               :string
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
+#  id                     :bigint           not null, primary key
+#  approved               :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
-#  confirmation_sent_at   :datetime
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
 #  unconfirmed_email      :string
+#  username               :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
@@ -39,10 +40,54 @@ class User < ApplicationRecord
   has_many :ingredients
 
   after_create :assign_default_role
+  after_create :send_admin_email
+
+  # Determines if a user is allowed to be authenticated, if they pass existing Devise authentication logic as well as
+  #   being approved by an admin user
+  #
+  # @return [Boolean]
+  def active_for_authentication?
+    super && approved?
+  end
+
+  # Sends appropriate message for if the user is inactive or not, based on if they are approved or not
+  #
+  # @return [String]
+  def inactive_message
+    approved? ? super : :not_approved
+  end
+
+  def self.send_reset_password_instructions(attributes = {})
+    recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+    if !recoverable.approved?
+      recoverable.errors[:base] << I18n.t('devise.failure.not_approved')
+    elsif recoverable.persisted?
+      recoverable.send_reset_password_instructions
+    end
+    recoverable
+  end
+
+  def approve
+    self.approved = true
+    save
+  end
+
+  def unapprove
+    self.approved = false
+    save
+  end
 
   private
 
   def assign_default_role
     add_role(Role::DEFAULT) if roles.blank?
+  end
+
+  # Send an email to admin users indicating newly created user needs approval
+  def send_admin_email
+    # Only send new user approval email request email if user has not already been approved. This prevents sending this
+    #   email unnecessarily if the user has already been approved, while also making things easier for tests where we
+    #   do not need to go through the approval email flow for simple unit tests not involving the approval flow
+    AdminMailer.new_user_waiting_for_approval(email).deliver unless approved?
   end
 end

--- a/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
+++ b/app/views/admin_mailer/new_user_waiting_for_approval.html.erb
@@ -1,0 +1,2 @@
+<p><%= @email %> has registered to join A Lazy Kitchen!</p>
+<p>An admin can approve this registration by visiting the website and approving the user.</p>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,7 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      not_approved: "Your account has not been approved by your administrator yet."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -42,6 +43,7 @@ en:
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      signed_up_but_not_approved: "You have signed up successfully but your account has not been approved by your administrator yet."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."

--- a/db/migrate/20220213052943_add_approved_to_user.rb
+++ b/db/migrate/20220213052943_add_approved_to_user.rb
@@ -1,0 +1,8 @@
+class AddApprovedToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :approved, :boolean, default: false, null: false
+  end
+
+  # Approve all current users that should be considered approved, so that they may still use their accounts
+  # User.all.each{|user| user.approve}
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_12_013801) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_02_13_052943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -25,7 +24,7 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -38,7 +37,7 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -53,8 +52,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "last_name"
     t.string "middle_name"
     t.bigint "citation_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["citation_id"], name: "index_authors_on_citation_id"
     t.index ["last_name", "first_name"], name: "index_authors_on_last_name_and_first_name"
   end
@@ -72,8 +71,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.date "last_accessed_at"
     t.string "site_link"
     t.bigint "recipe_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["recipe_id"], name: "index_citations_on_recipe_id"
   end
 
@@ -82,7 +81,7 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
     t.string "scope"
-    t.datetime "created_at", precision: 6
+    t.datetime "created_at"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
@@ -91,8 +90,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
   create_table "ingredients", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.string "slug"
     t.string "ancestry"
@@ -106,8 +105,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.text "content", null: false
     t.string "notable_type", null: false
     t.bigint "notable_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["notable_type", "notable_id"], name: "index_notes_on_notable"
   end
 
@@ -115,8 +114,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "name", null: false
     t.text "description"
     t.boolean "publicly_accessible", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.string "slug"
     t.index ["name", "user_id"], name: "index_recipes_on_name_and_user_id", unique: true
@@ -128,8 +127,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "name"
     t.string "resource_type"
     t.bigint "resource_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
   end
@@ -140,8 +139,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "condition"
     t.bigint "step_id", null: false
     t.bigint "ingredient_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["ingredient_id"], name: "index_step_ingredients_on_ingredient_id"
     t.index ["step_id"], name: "index_step_ingredients_on_step_id"
   end
@@ -150,8 +149,8 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.integer "order", null: false
     t.text "instruction", null: false
     t.bigint "recipe_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["recipe_id"], name: "index_steps_on_recipe_id"
   end
 
@@ -160,14 +159,15 @@ ActiveRecord::Schema.define(version: 2022_02_12_013801) do
     t.string "username"
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: 6
-    t.datetime "remember_created_at", precision: 6
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: 6
-    t.datetime "confirmation_sent_at", precision: 6
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "approved", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/notes/ROADMAP.md
+++ b/notes/ROADMAP.md
@@ -13,6 +13,7 @@
   - Comments
 - CookLang Support
 - Maintenance Mode for Recipes Currently Undergoing Heavy Changes
+- Alerting and Monitoring tools
 
 ## Workflow
 - GitHub Actions Workflows

--- a/test/factories/authors.rb
+++ b/test/factories/authors.rb
@@ -2,18 +2,22 @@
 #
 # Table name: authors
 #
-#  id          :integer          not null, primary key
+#  id          :bigint           not null, primary key
 #  first_name  :string           not null
 #  last_name   :string
 #  middle_name :string
-#  citation_id :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  citation_id :bigint           not null
 #
 # Indexes
 #
 #  index_authors_on_citation_id               (citation_id)
 #  index_authors_on_last_name_and_first_name  (last_name,first_name)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (citation_id => citations.id)
 #
 
 FactoryBot.define do

--- a/test/factories/citations.rb
+++ b/test/factories/citations.rb
@@ -2,25 +2,29 @@
 #
 # Table name: citations
 #
-#  id                   :integer          not null, primary key
-#  origin               :string           not null
-#  content_type         :string           not null
-#  publication_title    :string
-#  publication_location :string
-#  publisher            :string
-#  published_at         :date
+#  id                   :bigint           not null, primary key
 #  content_location     :string
-#  version              :string
-#  site_title           :string
+#  content_type         :string           not null
 #  last_accessed_at     :date
+#  origin               :string           not null
+#  publication_location :string
+#  publication_title    :string
+#  published_at         :date
+#  publisher            :string
 #  site_link            :string
-#  recipe_id            :integer          not null
+#  site_title           :string
+#  version              :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  recipe_id            :bigint           not null
 #
 # Indexes
 #
 #  index_citations_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 FactoryBot.define do

--- a/test/factories/ingredients.rb
+++ b/test/factories/ingredients.rb
@@ -2,14 +2,14 @@
 #
 # Table name: ingredients
 #
-#  id          :integer          not null, primary key
-#  name        :string           not null
+#  id          :bigint           not null, primary key
+#  ancestry    :string
 #  description :text
+#  name        :string           not null
+#  slug        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  user_id     :integer
-#  slug        :string
-#  ancestry    :string
+#  user_id     :bigint
 #
 # Indexes
 #
@@ -17,6 +17,10 @@
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 FactoryBot.define do

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -2,12 +2,12 @@
 #
 # Table name: notes
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  content      :text             not null
 #  notable_type :string           not null
-#  notable_id   :integer          not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  notable_id   :bigint           not null
 #
 # Indexes
 #

--- a/test/factories/recipes.rb
+++ b/test/factories/recipes.rb
@@ -2,20 +2,24 @@
 #
 # Table name: recipes
 #
-#  id                  :integer          not null, primary key
-#  name                :string           not null
+#  id                  :bigint           not null, primary key
 #  description         :text
-#  publicly_accessible :boolean          default("false"), not null
+#  name                :string           not null
+#  publicly_accessible :boolean          default(FALSE), not null
+#  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  user_id             :integer
-#  slug                :string
+#  user_id             :bigint
 #
 # Indexes
 #
 #  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_recipes_on_slug              (slug) UNIQUE
 #  index_recipes_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 FactoryBot.define do

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -2,12 +2,12 @@
 #
 # Table name: roles
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  resource_type :string
-#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  resource_id   :bigint
 #
 # Indexes
 #

--- a/test/factories/step_ingredients.rb
+++ b/test/factories/step_ingredients.rb
@@ -2,19 +2,24 @@
 #
 # Table name: step_ingredients
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  amount        :decimal(, )      not null
-#  unit          :string
 #  condition     :string
-#  step_id       :integer          not null
-#  ingredient_id :integer          not null
+#  unit          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  ingredient_id :bigint           not null
+#  step_id       :bigint           not null
 #
 # Indexes
 #
 #  index_step_ingredients_on_ingredient_id  (ingredient_id)
 #  index_step_ingredients_on_step_id        (step_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (ingredient_id => ingredients.id)
+#  fk_rails_...  (step_id => steps.id)
 #
 
 FactoryBot.define do

--- a/test/factories/steps.rb
+++ b/test/factories/steps.rb
@@ -2,16 +2,20 @@
 #
 # Table name: steps
 #
-#  id          :integer          not null, primary key
-#  order       :integer          not null
+#  id          :bigint           not null, primary key
 #  instruction :text             not null
-#  recipe_id   :integer          not null
+#  order       :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  recipe_id   :bigint           not null
 #
 # Indexes
 #
 #  index_steps_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 FactoryBot.define do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -2,17 +2,18 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string           default(""), not null
-#  username               :string
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
+#  id                     :bigint           not null, primary key
+#  approved               :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
-#  confirmation_sent_at   :datetime
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
 #  unconfirmed_email      :string
+#  username               :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
@@ -31,6 +32,9 @@ FactoryBot.define do
     password { 'password' }
     # Default users to be confirmed so that tests may be performed using them
     confirmed_at { DateTime.now }
+    # Default users to be approved so that tests may be performed using them
+    approved { true }
+
     factory :user_with_full_recipes do
       transient do
         recipes_count { 5 }

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -2,20 +2,24 @@
 #
 # Table name: recipes
 #
-#  id                  :integer          not null, primary key
-#  name                :string           not null
+#  id                  :bigint           not null, primary key
 #  description         :text
-#  publicly_accessible :boolean          default("false"), not null
+#  name                :string           not null
+#  publicly_accessible :boolean          default(FALSE), not null
+#  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  user_id             :integer
-#  slug                :string
+#  user_id             :bigint
 #
 # Indexes
 #
 #  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_recipes_on_slug              (slug) UNIQUE
 #  index_recipes_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AdminMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/admin_mailer
+class AdminMailerPreview < ActionMailer::Preview
+
+end

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -2,18 +2,22 @@
 #
 # Table name: authors
 #
-#  id          :integer          not null, primary key
+#  id          :bigint           not null, primary key
 #  first_name  :string           not null
 #  last_name   :string
 #  middle_name :string
-#  citation_id :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  citation_id :bigint           not null
 #
 # Indexes
 #
 #  index_authors_on_citation_id               (citation_id)
 #  index_authors_on_last_name_and_first_name  (last_name,first_name)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (citation_id => citations.id)
 #
 
 require "test_helper"

--- a/test/models/citation_test.rb
+++ b/test/models/citation_test.rb
@@ -2,25 +2,29 @@
 #
 # Table name: citations
 #
-#  id                   :integer          not null, primary key
-#  origin               :string           not null
-#  content_type         :string           not null
-#  publication_title    :string
-#  publication_location :string
-#  publisher            :string
-#  published_at         :date
+#  id                   :bigint           not null, primary key
 #  content_location     :string
-#  version              :string
-#  site_title           :string
+#  content_type         :string           not null
 #  last_accessed_at     :date
+#  origin               :string           not null
+#  publication_location :string
+#  publication_title    :string
+#  published_at         :date
+#  publisher            :string
 #  site_link            :string
-#  recipe_id            :integer          not null
+#  site_title           :string
+#  version              :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  recipe_id            :bigint           not null
 #
 # Indexes
 #
 #  index_citations_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 require "test_helper"

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -2,14 +2,14 @@
 #
 # Table name: ingredients
 #
-#  id          :integer          not null, primary key
-#  name        :string           not null
+#  id          :bigint           not null, primary key
+#  ancestry    :string
 #  description :text
+#  name        :string           not null
+#  slug        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  user_id     :integer
-#  slug        :string
-#  ancestry    :string
+#  user_id     :bigint
 #
 # Indexes
 #
@@ -17,6 +17,10 @@
 #  index_ingredients_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_ingredients_on_slug              (slug) UNIQUE
 #  index_ingredients_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 require "test_helper"

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -2,12 +2,12 @@
 #
 # Table name: notes
 #
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #  content      :text             not null
 #  notable_type :string           not null
-#  notable_id   :integer          not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  notable_id   :bigint           not null
 #
 # Indexes
 #

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -2,20 +2,24 @@
 #
 # Table name: recipes
 #
-#  id                  :integer          not null, primary key
-#  name                :string           not null
+#  id                  :bigint           not null, primary key
 #  description         :text
-#  publicly_accessible :boolean          default("false"), not null
+#  name                :string           not null
+#  publicly_accessible :boolean          default(FALSE), not null
+#  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  user_id             :integer
-#  slug                :string
+#  user_id             :bigint
 #
 # Indexes
 #
 #  index_recipes_on_name_and_user_id  (name,user_id) UNIQUE
 #  index_recipes_on_slug              (slug) UNIQUE
 #  index_recipes_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 
 require "test_helper"

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -2,12 +2,12 @@
 #
 # Table name: roles
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  resource_type :string
-#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  resource_id   :bigint
 #
 # Indexes
 #

--- a/test/models/step_ingredient_test.rb
+++ b/test/models/step_ingredient_test.rb
@@ -2,19 +2,24 @@
 #
 # Table name: step_ingredients
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  amount        :decimal(, )      not null
-#  unit          :string
 #  condition     :string
-#  step_id       :integer          not null
-#  ingredient_id :integer          not null
+#  unit          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  ingredient_id :bigint           not null
+#  step_id       :bigint           not null
 #
 # Indexes
 #
 #  index_step_ingredients_on_ingredient_id  (ingredient_id)
 #  index_step_ingredients_on_step_id        (step_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (ingredient_id => ingredients.id)
+#  fk_rails_...  (step_id => steps.id)
 #
 
 require "test_helper"

--- a/test/models/step_test.rb
+++ b/test/models/step_test.rb
@@ -2,16 +2,20 @@
 #
 # Table name: steps
 #
-#  id          :integer          not null, primary key
-#  order       :integer          not null
+#  id          :bigint           not null, primary key
 #  instruction :text             not null
-#  recipe_id   :integer          not null
+#  order       :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  recipe_id   :bigint           not null
 #
 # Indexes
 #
 #  index_steps_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
 #
 
 require "test_helper"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,17 +2,18 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string           default(""), not null
-#  username               :string
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
+#  id                     :bigint           not null, primary key
+#  approved               :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
-#  confirmation_sent_at   :datetime
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
 #  unconfirmed_email      :string
+#  username               :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/test/system/authentication_test.rb
+++ b/test/system/authentication_test.rb
@@ -2,7 +2,10 @@ require "test_helper"
 
 class AuthenticationTest < ApplicationSystemTestCase
   setup do
-
+    admin_user = FactoryBot.create(:user)
+    # Ensure that an admin-level user has been created so that there are admins to receive
+    #   user registration approval emails
+    admin_user.add_role(:admin)
   end
 
   test 'sign up' do
@@ -20,7 +23,7 @@ class AuthenticationTest < ApplicationSystemTestCase
     click_button('Sign up')
 
     assert page.has_selector?('.flash-container.flash-notice')
-    assert page.has_selector?('.flash-message', text: I18n.t('devise.registrations.signed_up_but_unconfirmed'))
+    assert page.has_selector?('.flash-message', text: I18n.t('devise.registrations.signed_up_but_not_approved'))
   end
 
   test 'login' do


### PR DESCRIPTION
## Motivation

When inspecting my database, I noticed an email from a foreign country that seemed to be associated with spam/malicious actions. In order to prevent abuse of my site's limited resources, and considering no one uses this site yet, I decided to make  it so that a user requires the approval of an admin (i.e. **me**) before they may actually authenticate (login).

This way, a user cannot login and abuse my site's resource at this point without my manual approval.

## Changes
- Add 'approval workflow' to Devise signup and authentication processes so that a user must be confirmed by an admin before being able to successfully authenticate
  - Require user to be `approved` before being able to login
  - Email admin users on user registration to notify of a new user that wants to login

## TODOs
- CAPTCHA - I think this is a lower priority than just blocking users that don't have my approval, but it might be good to cut down on spam. At this point I'm still evaluating options; I may just go with Google's solution, but I found a few other solutions that seem interesting.